### PR TITLE
refactor(game): remove LeetCode CRUD from GameService and GameControl…

### DIFF
--- a/backend/internal/controller/game_controller.go
+++ b/backend/internal/controller/game_controller.go
@@ -55,28 +55,6 @@ func (c *GameController) GetGame(ctx *gin.Context) {
 	})
 }
 
-// REMOVED: ListGames - no longer needed with automatic matching
-
-// ListLeetCodes LeetCode 문제 목록 조회 핸들러
-func (c *GameController) ListLeetCodes(ctx *gin.Context) {
-	// LeetCode 문제 목록 조회
-	leetcodes, err := c.gameService.ListLeetCodes()
-	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{
-			"success": false,
-			"message": err.Error(),
-		})
-		return
-	}
-
-	ctx.JSON(http.StatusOK, gin.H{
-		"success":   true,
-		"leetcodes": leetcodes,
-	})
-}
-
-// REMOVED: JoinGame - replaced by automatic matching via WebSocket
-
 // SubmitSolution 코드 제출 핸들러
 func (c *GameController) SubmitSolution(ctx *gin.Context) {
 	// 사용자 ID 가져오기
@@ -134,108 +112,6 @@ func (c *GameController) SubmitSolution(ctx *gin.Context) {
 		"is_winner": result.IsWinner,
 		"message":   result.Message,
 	})
-}
-
-// REMOVED: CloseGame - no room concept in matching system
-
-// GameController에 메서드 추가
-func (c *GameController) CreateLeetCode(ctx *gin.Context) {
-	var req model.CreateLeetCodeRequest
-	if err := ctx.ShouldBindJSON(&req); err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{
-			"success": false,
-			"message": "Invalid request: " + err.Error(),
-		})
-		return
-	}
-
-	leetcode, err := c.gameService.CreateLeetCode(&req)
-	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{
-			"success": false,
-			"message": err.Error(),
-		})
-		return
-	}
-
-	ctx.JSON(http.StatusCreated, gin.H{
-		"success":  true,
-		"leetcode": leetcode,
-	})
-}
-
-func (c *GameController) UpdateLeetCode(ctx *gin.Context) {
-	id, err := uuid.Parse(ctx.Param("id"))
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{
-			"success": false,
-			"message": "Invalid ID format",
-		})
-		return
-	}
-
-	var req model.UpdateLeetCodeRequest
-	if err := ctx.ShouldBindJSON(&req); err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{
-			"success": false,
-			"message": "Invalid request: " + err.Error(),
-		})
-		return
-	}
-
-	leetcode, err := c.gameService.UpdateLeetCode(id, &req)
-	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{
-			"success": false,
-			"message": err.Error(),
-		})
-		return
-	}
-
-	ctx.JSON(http.StatusOK, gin.H{
-		"success":  true,
-		"leetcode": leetcode,
-	})
-}
-
-func (c *GameController) DeleteLeetCode(ctx *gin.Context) {
-	id, err := uuid.Parse(ctx.Param("id"))
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{
-			"success": false,
-			"message": "Invalid ID format",
-		})
-		return
-	}
-
-	if err := c.gameService.DeleteLeetCode(id); err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{
-			"success": false,
-			"message": err.Error(),
-		})
-		return
-	}
-
-	ctx.JSON(http.StatusOK, gin.H{
-		"success": true,
-		"message": "Successfully deleted",
-	})
-}
-
-func (c *GameController) GetLeetCode(ctx *gin.Context) {
-	id, err := uuid.Parse(ctx.Param("id"))
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid ID format"})
-		return
-	}
-
-	leetcode, err := c.gameService.GetLeetCode(id)
-	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-
-	ctx.JSON(http.StatusOK, leetcode)
 }
 
 // CreateGameFromMatch creates a game from a completed match

--- a/backend/internal/controller/game_controller_test.go
+++ b/backend/internal/controller/game_controller_test.go
@@ -48,46 +48,12 @@ func (m *MockGameService) GetPlayerCode(gameID uuid.UUID, userID uuid.UUID) (str
 	return args.String(0), args.Error(1)
 }
 
-// LeetCode management
-func (m *MockGameService) ListLeetCodes() ([]*model.LeetCodeSummary, error) {
-	args := m.Called()
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).([]*model.LeetCodeSummary), args.Error(1)
-}
+// LeetCode CRUD removed from GameService
 
 // REMOVED: Room-based API mocks (replaced by WebSocket matching)
 // CreateGame, ListGames, JoinGame, CloseGame - no longer part of interface
 
-func (m *MockGameService) CreateLeetCode(req *model.CreateLeetCodeRequest) (*model.LeetCodeDetail, error) {
-	args := m.Called(req)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*model.LeetCodeDetail), args.Error(1)
-}
-
-func (m *MockGameService) UpdateLeetCode(id uuid.UUID, req *model.UpdateLeetCodeRequest) (*model.LeetCodeDetail, error) {
-	args := m.Called(id, req)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*model.LeetCodeDetail), args.Error(1)
-}
-
-func (m *MockGameService) DeleteLeetCode(id uuid.UUID) error {
-	args := m.Called(id)
-	return args.Error(0)
-}
-
-func (m *MockGameService) GetLeetCode(id uuid.UUID) (*model.LeetCodeDetail, error) {
-	args := m.Called(id)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*model.LeetCodeDetail), args.Error(1)
-}
+// removed: Create/Update/Delete/Get LeetCode
 
 // Matchmaking methods
 func (m *MockGameService) CreateGameForMatch(player1ID, player2ID uuid.UUID, difficulty string) (*model.Game, error) {

--- a/backend/internal/service/game_service.go
+++ b/backend/internal/service/game_service.go
@@ -25,12 +25,6 @@ type GameService interface {
 	CreateGameForMatch(player1ID, player2ID uuid.UUID, difficulty string) (*model.Game, error)
 	GetRandomLeetCodeByDifficulty(difficulty string) (*model.LeetCode, error)
 	CreateGameFromMatch(matchID string, userID uuid.UUID) (*model.GameResponse, error)
-
-	ListLeetCodes() ([]*model.LeetCodeSummary, error)
-	CreateLeetCode(req *model.CreateLeetCodeRequest) (*model.LeetCodeDetail, error)
-	UpdateLeetCode(id uuid.UUID, req *model.UpdateLeetCodeRequest) (*model.LeetCodeDetail, error)
-	DeleteLeetCode(id uuid.UUID) error
-	GetLeetCode(id uuid.UUID) (*model.LeetCodeDetail, error)
 }
 
 // gameService GameService 인터페이스 구현체
@@ -69,20 +63,7 @@ func (s *gameService) GetGame(gameID uuid.UUID) (*model.GameResponse, error) {
 	return game.ToResponse(), nil
 }
 
-// ListLeetCodes LeetCode 문제 목록 조회
-func (s *gameService) ListLeetCodes() ([]*model.LeetCodeSummary, error) {
-	leetcodes, err := s.leetCodeRepo.FindAll()
-	if err != nil {
-		return nil, err
-	}
-
-	var result []*model.LeetCodeSummary
-	for _, leetcode := range leetcodes {
-		result = append(result, leetcode.ToSummaryResponse())
-	}
-
-	return result, nil
-}
+// ListLeetCodes removed: LeetCode CRUD는 LeetCodeService로 통합
 
 // SubmitSolution 코드 제출 및 평가
 func (s *gameService) SubmitSolution(gameID uuid.UUID, userID uuid.UUID, req *model.SubmitSolutionRequest) (*model.SubmitSolutionResponse, error) {
@@ -273,73 +254,13 @@ func (s *gameService) CloseGame(gameID uuid.UUID, userID uuid.UUID) error {
 	return nil
 }
 
-func (s *gameService) CreateLeetCode(req *model.CreateLeetCodeRequest) (*model.LeetCodeDetail, error) {
-	leetcode := &model.LeetCode{
-		Title:              req.Title,
-		Description:        req.Description,
-		Examples:           req.Examples,
-		Constraints:        req.Constraints,
-		TestCases:          req.TestCases,
-		ExpectedOutputs:    req.ExpectedOutputs,
-		Difficulty:         req.Difficulty,
-		InputFormat:        req.InputFormat,
-		OutputFormat:       req.OutputFormat,
-		FunctionName:       req.FunctionName,
-		JavaScriptTemplate: req.JavaScriptTemplate,
-		PythonTemplate:     req.PythonTemplate,
-		GoTemplate:         req.GoTemplate,
-		JavaTemplate:       req.JavaTemplate,
-		CPPTemplate:        req.CPPTemplate,
-	}
+// CreateLeetCode removed: LeetCode CRUD는 LeetCodeService로 통합
 
-	if err := s.leetCodeRepo.Create(leetcode); err != nil {
-		return nil, err
-	}
+// UpdateLeetCode removed: LeetCode CRUD는 LeetCodeService로 통합
 
-	return leetcode.ToDetailResponse(), nil
-}
+// DeleteLeetCode removed: LeetCode CRUD는 LeetCodeService로 통합
 
-func (s *gameService) UpdateLeetCode(id uuid.UUID, req *model.UpdateLeetCodeRequest) (*model.LeetCodeDetail, error) {
-	leetcode, err := s.leetCodeRepo.FindByID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	// 필드 업데이트
-	leetcode.Title = req.Title
-	leetcode.Description = req.Description
-	leetcode.Examples = req.Examples
-	leetcode.Constraints = req.Constraints
-	leetcode.TestCases = req.TestCases
-	leetcode.ExpectedOutputs = req.ExpectedOutputs
-	leetcode.Difficulty = req.Difficulty
-	leetcode.InputFormat = req.InputFormat
-	leetcode.OutputFormat = req.OutputFormat
-	leetcode.FunctionName = req.FunctionName
-	leetcode.JavaScriptTemplate = req.JavaScriptTemplate
-	leetcode.PythonTemplate = req.PythonTemplate
-	leetcode.GoTemplate = req.GoTemplate
-	leetcode.JavaTemplate = req.JavaTemplate
-	leetcode.CPPTemplate = req.CPPTemplate
-
-	if err := s.leetCodeRepo.Update(leetcode); err != nil {
-		return nil, err
-	}
-
-	return leetcode.ToDetailResponse(), nil
-}
-
-func (s *gameService) DeleteLeetCode(id uuid.UUID) error {
-	return s.leetCodeRepo.Delete(id)
-}
-
-func (s *gameService) GetLeetCode(id uuid.UUID) (*model.LeetCodeDetail, error) {
-	leetcode, err := s.leetCodeRepo.FindByID(id)
-	if err != nil {
-		return nil, err
-	}
-	return leetcode.ToDetailResponse(), nil
-}
+// GetLeetCode removed: LeetCode CRUD는 LeetCodeService로 통합
 
 // CreateGameForMatch creates a new game for matched players
 func (s *gameService) CreateGameForMatch(player1ID, player2ID uuid.UUID, difficulty string) (*model.Game, error) {


### PR DESCRIPTION
…ler; consolidate CRUD in LeetCodeService

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes LeetCode CRUD/listing from GameService and GameController, updating tests and interfaces to consolidate CRUD in a dedicated service.
> 
> - **Backend**:
>   - **Service (`backend/internal/service/game_service.go`)**:
>     - Remove `GameService` methods: `ListLeetCodes`, `CreateLeetCode`, `UpdateLeetCode`, `DeleteLeetCode`, `GetLeetCode`.
>     - Delete corresponding implementations and related code paths.
>     - Keep matchmaking APIs (`CreateGameForMatch`, `GetRandomLeetCodeByDifficulty`, `CreateGameFromMatch`) and gameplay (`SubmitSolution`, code update/retrieval).
>   - **Controller (`backend/internal/controller/game_controller.go`)**:
>     - Remove LeetCode endpoints: `ListLeetCodes`, `CreateLeetCode`, `UpdateLeetCode`, `DeleteLeetCode`, `GetLeetCode`.
>     - Retain gameplay endpoints (`GetGame`, `SubmitSolution`, `CreateGameFromMatch`).
> - **Tests (`backend/internal/controller/game_controller_test.go`)**:
>   - Update `MockGameService` to drop LeetCode CRUD/listing methods.
>   - Keep tests for active gameplay (e.g., `GetGame`, `SubmitSolution`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97f0c93b1ddb06c0eda316c652f98874381fd21e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->