### PR TITLE
feat(matchmaking): segment queues by mode+difficulty and plumb mode\n…

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -139,7 +139,7 @@ func initializeServices(repos *repositories, rdb *redis.Client, cfg *config.Conf
 	authService := service.NewAuthService(repos.userRepository, cfg.JWTSecret, appLogger)
 	userService := service.NewUserService(repos.userRepository, repos.matchRepository, appLogger)
 	judgeService := service.NewJudgeService(cfg.Judge0APIKey, cfg.Judge0APIEndpoint, appLogger)
-	matchService := service.NewMatchService(repos.matchRepository, repos.leetCodeRepo, rdb, judgeService, appLogger)
+	matchService := service.NewMatchService(repos.matchRepository, repos.leetCodeRepo, rdb, judgeService, repos.userRepository, appLogger)
 
 	// Initialize EventBus
 	eventBus := events.NewEventBus()

--- a/backend/internal/service/integration_test.go
+++ b/backend/internal/service/integration_test.go
@@ -37,10 +37,10 @@ func TestMatchmakingIntegration_Success(t *testing.T) {
 		Status:    "playing",
 	}
 
-	mockMatchService.On("CreateMatch", player1ID, player2ID, difficulty).Return(mockMatch, nil)
+	mockMatchService.On("CreateMatch", player1ID, player2ID, difficulty, "casual_pvp").Return(mockMatch, nil)
 
 	// Execute
-	result, err := matchmakingService.CreateMatch(player1ID, player2ID, difficulty)
+    result, err := matchmakingService.CreateMatch(player1ID, player2ID, difficulty, "casual_pvp")
 
 	// Assert
 	assert.NoError(t, err)
@@ -93,10 +93,10 @@ func TestMatchmakingIntegration_ErrorHandling(t *testing.T) {
 	difficulty := "hard"
 
 	// Mock match creation failure
-	mockMatchService.On("CreateMatch", player1ID, player2ID, difficulty).Return((*model.Match)(nil), assert.AnError)
+	mockMatchService.On("CreateMatch", player1ID, player2ID, difficulty, "casual_pvp").Return((*model.Match)(nil), assert.AnError)
 
 	// Execute
-	result, err := matchmakingService.CreateMatch(player1ID, player2ID, difficulty)
+    result, err := matchmakingService.CreateMatch(player1ID, player2ID, difficulty, "casual_pvp")
 
 	// Assert
 	assert.Error(t, err)

--- a/backend/internal/service/integration_test.go
+++ b/backend/internal/service/integration_test.go
@@ -35,12 +35,13 @@ func TestMatchmakingIntegration_Success(t *testing.T) {
 		PlayerAID: player1ID,
 		PlayerBID: &player2ID,
 		Status:    "playing",
+		Mode:      model.MatchModeRankedPVP,
 	}
 
 	mockMatchService.On("CreateMatch", player1ID, player2ID, difficulty, "casual_pvp").Return(mockMatch, nil)
 
 	// Execute
-    result, err := matchmakingService.CreateMatch(player1ID, player2ID, difficulty, "casual_pvp")
+	result, err := matchmakingService.CreateMatch(player1ID, player2ID, difficulty, "casual_pvp")
 
 	// Assert
 	assert.NoError(t, err)
@@ -96,7 +97,7 @@ func TestMatchmakingIntegration_ErrorHandling(t *testing.T) {
 	mockMatchService.On("CreateMatch", player1ID, player2ID, difficulty, "casual_pvp").Return((*model.Match)(nil), assert.AnError)
 
 	// Execute
-    result, err := matchmakingService.CreateMatch(player1ID, player2ID, difficulty, "casual_pvp")
+	result, err := matchmakingService.CreateMatch(player1ID, player2ID, difficulty, "casual_pvp")
 
 	// Assert
 	assert.Error(t, err)

--- a/backend/internal/service/match_service.go
+++ b/backend/internal/service/match_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/Dongmoon29/code_racer/internal/interfaces"
@@ -33,6 +34,7 @@ type matchService struct {
 	redisManager *RedisManager
 	logger       logger.Logger
 	judgeService interfaces.JudgeService
+	userRepo     interfaces.UserRepository
 }
 
 // NewMatchService creates a new MatchService instance with the provided dependencies
@@ -41,6 +43,7 @@ func NewMatchService(
 	leetCodeRepo repository.LeetCodeRepository,
 	rdb *redis.Client,
 	judgeService interfaces.JudgeService,
+	userRepo interfaces.UserRepository,
 	logger logger.Logger,
 ) MatchService {
 	return &matchService{
@@ -49,25 +52,26 @@ func NewMatchService(
 		rdb:          rdb,
 		redisManager: NewRedisManager(rdb, logger),
 		judgeService: judgeService,
+		userRepo:     userRepo,
 		logger:       logger,
 	}
 }
 
-// SubmitSolution 코드 제출 및 평가
+// SubmitSolution handles code submission and evaluation
 func (s *matchService) SubmitSolution(matchID uuid.UUID, userID uuid.UUID, req *model.SubmitSolutionRequest) (*model.SubmitSolutionResponse, error) {
 	s.logger.Debug().
 		Str("matchID", matchID.String()).
 		Str("userID", userID.String()).
 		Msg("Starting solution submission")
 
-	// 게임 정보 조회
+		// Fetch match from repository
 	match, err := s.matchRepo.FindByID(matchID)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("Failed to find game")
 		return nil, err
 	}
 
-	// 게임 상태 체크
+	// Validate match status
 	if match.Status != model.MatchStatusPlaying {
 		s.logger.Error().
 			Str("status", string(match.Status)).
@@ -80,7 +84,7 @@ func (s *matchService) SubmitSolution(matchID uuid.UUID, userID uuid.UUID, req *
 		Str("language", req.Language).
 		Msg("Evaluating submitted code")
 
-	// Judge0 API를 통해 코드 평가
+		// Evaluate code via Judge service (Judge0)
 	result, err := s.judgeService.EvaluateCode(req.Code, req.Language, &match.LeetCode)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("Code evaluation failed")
@@ -95,17 +99,17 @@ func (s *matchService) SubmitSolution(matchID uuid.UUID, userID uuid.UUID, req *
 		Str("errorMessage", result.ErrorMessage).
 		Msg("Code evaluation completed")
 
-	// 코드가 모든 테스트 케이스를 통과했는지 확인
+		// Check if all test cases passed
 	if result.Passed {
 		s.logger.Debug().Msg("All test cases passed, setting winner")
 
-		// 분산 락을 사용한 승자 설정 (동시 제출 방지)
+		// Set winner using a distributed lock (prevent race on simultaneous submits)
 		ctx := context.Background()
 		lockKey := fmt.Sprintf("match:%s:winner_lock", matchID.String())
 		lockValue := userID.String()
 		lockExpiry := 10 * time.Second
 
-		// 분산 락 획득 시도
+		// Try to acquire the distributed lock
 		lockAcquired, err := s.rdb.SetNX(ctx, lockKey, lockValue, lockExpiry).Result()
 		if err != nil {
 			s.logger.Error().Err(err).Msg("Failed to acquire winner lock")
@@ -113,7 +117,7 @@ func (s *matchService) SubmitSolution(matchID uuid.UUID, userID uuid.UUID, req *
 		}
 
 		if !lockAcquired {
-			// 다른 플레이어가 이미 승리했음
+			// Another player already won
 			s.logger.Info().Msg("Another player already won the game")
 			return &model.SubmitSolutionResponse{
 				Success:  true,
@@ -122,24 +126,54 @@ func (s *matchService) SubmitSolution(matchID uuid.UUID, userID uuid.UUID, req *
 			}, nil
 		}
 
-		// 락 해제를 위한 defer 설정
+		// Ensure lock is released (defer)
 		defer func() {
 			s.rdb.Del(ctx, lockKey)
 		}()
 
-		// 승자 설정
+		// Persist winner in DB
 		if err := s.matchRepo.SetWinner(matchID, userID); err != nil {
 			s.logger.Error().Err(err).Msg("Failed to set winner")
 			return nil, err
 		}
 
-		// Redis에서 게임 상태 업데이트
+		// Update match status in Redis
 		matchKey := fmt.Sprintf("match:%s", matchID.String())
 		if err := s.rdb.HSet(ctx, matchKey, "status", string(model.MatchStatusFinished)).Err(); err != nil {
 			s.logger.Error().Err(err).Msg("Failed to update match status in Redis")
 		}
 
-		// Game end notification will be handled by real-time WebSocket updates
+		// ELO update for ranked matches
+		// Reload match to ensure we have the latest mode and participants
+		updatedMatch, err := s.matchRepo.FindByID(matchID)
+		if err == nil && updatedMatch != nil && updatedMatch.Mode == model.MatchModeRankedPVP && updatedMatch.PlayerBID != nil {
+			winnerID := userID
+			var loserID uuid.UUID
+			if winnerID == updatedMatch.PlayerAID {
+				loserID = *updatedMatch.PlayerBID
+			} else {
+				loserID = updatedMatch.PlayerAID
+			}
+
+			// Fetch users
+			winner, err1 := s.userRepo.FindByID(winnerID)
+			loser, err2 := s.userRepo.FindByID(loserID)
+			if err1 == nil && err2 == nil && winner != nil && loser != nil {
+				newWinner, newLoser := applyElo(winner.Rating, loser.Rating, true)
+				winner.Rating = newWinner
+				loser.Rating = newLoser
+				if err := s.userRepo.Update(winner); err != nil {
+					s.logger.Error().Err(err).Msg("Failed to update winner rating")
+				}
+				if err := s.userRepo.Update(loser); err != nil {
+					s.logger.Error().Err(err).Msg("Failed to update loser rating")
+				}
+			} else {
+				s.logger.Warn().Msg("Failed to load users for ELO update")
+			}
+		}
+
+		// Game end notification will be handled by WebSocket layer
 		s.logger.Info().Msg("Match completed - winner determined")
 
 		return &model.SubmitSolutionResponse{
@@ -157,19 +191,44 @@ func (s *matchService) SubmitSolution(matchID uuid.UUID, userID uuid.UUID, req *
 	}, nil
 }
 
-// UpdateCode 코드 업데이트 및 웹소켓 브로드캐스트
+// applyElo applies ELO update with K-factor to winner/loser ratings.
+// Returns updated ratings (winnerNew, loserNew).
+func applyElo(winnerRating int, loserRating int, winnerWon bool) (int, int) {
+	const kFactor = 32.0
+	ra := float64(winnerRating)
+	rb := float64(loserRating)
+	ea := 1.0 / (1.0 + math.Pow(10.0, (rb-ra)/400.0))
+	eb := 1.0 - ea
+	var sa, sb float64
+	if winnerWon {
+		sa, sb = 1.0, 0.0
+	} else {
+		sa, sb = 0.0, 1.0
+	}
+	newRA := int(math.Round(ra + kFactor*(sa-ea)))
+	newRB := int(math.Round(rb + kFactor*(sb-eb)))
+	if newRA < 0 {
+		newRA = 0
+	}
+	if newRB < 0 {
+		newRB = 0
+	}
+	return newRA, newRB
+}
+
+// UpdateCode stores user's code in Redis and will be broadcasted by WebSocket layer
 func (s *matchService) UpdateCode(matchID uuid.UUID, userID uuid.UUID, code string) error {
 	match, err := s.matchRepo.FindByID(matchID)
 	if err != nil {
 		return err
 	}
 
-	// 게임 상태 체크
+	// Validate match status
 	if match.Status != model.MatchStatusPlaying {
 		return errors.New("match is not in playing status")
 	}
 
-	// Redis에 코드 저장
+	// Persist code in Redis
 	if err := s.redisManager.UpdateUserCode(matchID, userID, code); err != nil {
 		return err
 	}
@@ -177,27 +236,27 @@ func (s *matchService) UpdateCode(matchID uuid.UUID, userID uuid.UUID, code stri
 	return nil
 }
 
-// GetPlayerCode 플레이어 코드 조회
+// GetPlayerCode returns the user's code snapshot stored in Redis
 func (s *matchService) GetPlayerCode(matchID uuid.UUID, userID uuid.UUID) (string, error) {
 	return s.redisManager.GetUserCode(matchID, userID)
 }
 
 func (s *matchService) CloseMatch(matchID uuid.UUID, userID uuid.UUID) error {
-	// DB에서 게임 방 닫기
+	// Close match in DB
 	if err := s.matchRepo.CloseMatch(matchID, userID); err != nil {
 		return err
 	}
 
-	// Redis에서 게임 관련 데이터 정리
+	// Cleanup match data in Redis
 	ctx := context.Background()
 
-	// 게임에 참가한 사용자 목록 가져오기
+	// Get participants in the match
 	users, err := s.redisManager.GetMatchUsers(matchID)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("Failed to get match users from Redis")
 	}
 
-	// 각 사용자를 매치에서 제거
+	// Remove each user from the match
 	for _, uid := range users {
 		userID, err := uuid.Parse(uid)
 		if err != nil {
@@ -209,19 +268,19 @@ func (s *matchService) CloseMatch(matchID uuid.UUID, userID uuid.UUID) error {
 		}
 	}
 
-	// 매치 완전 정리
+	// Cleanup all remaining match keys
 	if err := s.redisManager.CleanupMatch(matchID); err != nil {
 		s.logger.Error().Err(err).Msg("Failed to cleanup match")
 	}
 
-	// 승자 락 키도 정리
+	// Cleanup winner lock key as well
 	lockKey := fmt.Sprintf("match:%s:winner_lock", matchID.String())
 	s.rdb.Del(ctx, lockKey)
 
 	return nil
 }
 
-// GetMatch 매치 조회
+// GetMatch finds a match by ID
 func (s *matchService) GetMatch(matchID uuid.UUID) (*model.Match, error) {
 	match, err := s.matchRepo.FindByID(matchID)
 	if err != nil {
@@ -230,8 +289,9 @@ func (s *matchService) GetMatch(matchID uuid.UUID) (*model.Match, error) {
 	return match, nil
 }
 
+// CreateMatch persists a new match and initializes Redis state
 func (s *matchService) CreateMatch(player1ID, player2ID uuid.UUID, difficulty string, mode string) (*model.Match, error) {
-	// Get a random LeetCode problem for the difficulty
+	// Pick a random LeetCode problem for the requested difficulty
 	leetcode, err := s.GetRandomLeetCodeByDifficulty(difficulty)
 	if err != nil {
 		s.logger.Error().Err(err).Str("difficulty", difficulty).Msg("Failed to get random LeetCode problem")
@@ -252,7 +312,7 @@ func (s *matchService) CreateMatch(player1ID, player2ID uuid.UUID, difficulty st
 		return nil, fmt.Errorf("failed to create match: %w", err)
 	}
 
-	// Load the complete game with LeetCode details
+	// Load the complete match with associated LeetCode details
 	createdMatch, err := s.matchRepo.FindByID(match.ID)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("Failed to load created match")
@@ -262,7 +322,7 @@ func (s *matchService) CreateMatch(player1ID, player2ID uuid.UUID, difficulty st
 	// Initialize Redis data using RedisManager
 	if err := s.redisManager.CreateMatch(match.ID, player1ID, player2ID, leetcode.ID, difficulty, mode); err != nil {
 		s.logger.Error().Err(err).Msg("Failed to initialize Redis data for match")
-		// Try to clean up the database record
+		// Try to rollback the database record
 		if deleteErr := s.matchRepo.Delete(match.ID); deleteErr != nil {
 			s.logger.Error().Err(deleteErr).Msg("Failed to rollback match creation")
 		}

--- a/backend/internal/service/match_service.go
+++ b/backend/internal/service/match_service.go
@@ -21,7 +21,7 @@ type MatchService interface {
 
 	// Matchmaking methods
 	GetRandomLeetCodeByDifficulty(difficulty string) (*model.LeetCode, error)
-	CreateMatch(player1ID, player2ID uuid.UUID, difficulty string) (*model.Match, error)
+	CreateMatch(player1ID, player2ID uuid.UUID, difficulty string, mode string) (*model.Match, error)
 
 	// Query methods
 	GetMatch(matchID uuid.UUID) (*model.Match, error)
@@ -230,7 +230,7 @@ func (s *matchService) GetMatch(matchID uuid.UUID) (*model.Match, error) {
 	return match, nil
 }
 
-func (s *matchService) CreateMatch(player1ID, player2ID uuid.UUID, difficulty string) (*model.Match, error) {
+func (s *matchService) CreateMatch(player1ID, player2ID uuid.UUID, difficulty string, mode string) (*model.Match, error) {
 	// Get a random LeetCode problem for the difficulty
 	leetcode, err := s.GetRandomLeetCodeByDifficulty(difficulty)
 	if err != nil {
@@ -243,6 +243,7 @@ func (s *matchService) CreateMatch(player1ID, player2ID uuid.UUID, difficulty st
 		PlayerBID:  &player2ID,
 		LeetCodeID: leetcode.ID,
 		Status:     model.MatchStatusPlaying,
+		Mode:       model.MatchMode(mode),
 	}
 
 	// Save to database
@@ -259,7 +260,7 @@ func (s *matchService) CreateMatch(player1ID, player2ID uuid.UUID, difficulty st
 	}
 
 	// Initialize Redis data using RedisManager
-	if err := s.redisManager.CreateMatch(match.ID, player1ID, player2ID, leetcode.ID, difficulty); err != nil {
+	if err := s.redisManager.CreateMatch(match.ID, player1ID, player2ID, leetcode.ID, difficulty, mode); err != nil {
 		s.logger.Error().Err(err).Msg("Failed to initialize Redis data for match")
 		// Try to clean up the database record
 		if deleteErr := s.matchRepo.Delete(match.ID); deleteErr != nil {

--- a/backend/internal/service/match_service_elo_test.go
+++ b/backend/internal/service/match_service_elo_test.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyElo_WinnerHigherRating(t *testing.T) {
+	// Winner has higher rating; gain should be relatively small
+	winnerOld := 1600
+	loserOld := 1500
+
+	winnerNew, loserNew := applyElo(winnerOld, loserOld, true)
+
+	// Basic invariants
+	assert.Greater(t, winnerNew, winnerOld)
+	assert.Less(t, loserNew, loserOld)
+
+	// Conservation in expectation: total rating drift should be bounded by K
+	totalDrift := (winnerNew - winnerOld) + (loserNew - loserOld)
+	assert.LessOrEqual(t, int(math.Abs(float64(totalDrift))), 32)
+}
+
+func TestApplyElo_WinnerLowerRating(t *testing.T) {
+	// Winner is underdog; gain should be higher
+	winnerOld := 1400
+	loserOld := 1700
+
+	winnerNew, loserNew := applyElo(winnerOld, loserOld, true)
+
+	assert.Greater(t, winnerNew, winnerOld)
+	assert.Less(t, loserNew, loserOld)
+
+	// Underdog should gain >= around 20 with K=32 typically
+	assert.GreaterOrEqual(t, winnerNew-winnerOld, 20)
+}
+
+func TestApplyElo_NoNegativeRatings(t *testing.T) {
+	// Extreme edge: ensure ratings don't go negative
+	winnerOld := 0
+	loserOld := 0
+
+	// If winner loses (simulate by winnerWon=false), rating shouldn't go below 0
+	a, b := applyElo(winnerOld, loserOld, false)
+	assert.GreaterOrEqual(t, a, 0)
+	assert.GreaterOrEqual(t, b, 0)
+}

--- a/backend/internal/service/matchmaking_service.go
+++ b/backend/internal/service/matchmaking_service.go
@@ -9,7 +9,7 @@ import (
 
 // MatchmakingService handles player matching and game creation
 type MatchmakingService interface {
-	CreateMatch(player1ID, player2ID uuid.UUID, difficulty string) (interface{}, error)
+	CreateMatch(player1ID, player2ID uuid.UUID, difficulty string, mode string) (interface{}, error)
 }
 
 type matchmakingService struct {
@@ -42,14 +42,14 @@ func NewMatchmakingService(
 }
 
 // CreateMatch handles the complete match creation flow
-func (s *matchmakingService) CreateMatch(player1ID, player2ID uuid.UUID, difficulty string) (interface{}, error) {
+func (s *matchmakingService) CreateMatch(player1ID, player2ID uuid.UUID, difficulty string, mode string) (interface{}, error) {
 	s.logger.Info().
 		Str("player1ID", player1ID.String()).
 		Str("player2ID", player2ID.String()).
 		Str("difficulty", difficulty).
 		Msg("Starting match creation")
 
-	match, err := s.matchService.CreateMatch(player1ID, player2ID, difficulty)
+	match, err := s.matchService.CreateMatch(player1ID, player2ID, difficulty, mode)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("Failed to create match")
 		return nil, err

--- a/backend/internal/service/matchmaking_service_test.go
+++ b/backend/internal/service/matchmaking_service_test.go
@@ -38,8 +38,8 @@ func (m *MockMatchService) GetRandomLeetCodeByDifficulty(difficulty string) (*mo
 	return args.Get(0).(*model.LeetCode), args.Error(1)
 }
 
-func (m *MockMatchService) CreateMatch(player1ID, player2ID uuid.UUID, difficulty string) (*model.Match, error) {
-	args := m.Called(player1ID, player2ID, difficulty)
+func (m *MockMatchService) CreateMatch(player1ID, player2ID uuid.UUID, difficulty string, mode string) (*model.Match, error) {
+    args := m.Called(player1ID, player2ID, difficulty, mode)
 	return args.Get(0).(*model.Match), args.Error(1)
 }
 
@@ -81,10 +81,10 @@ func TestMatchmakingService_CreateMatch_Success(t *testing.T) {
 
 	// Mock match creation success
 	mockMatch := &model.Match{ID: uuid.New()}
-	mockMatchService.On("CreateMatch", player1ID, player2ID, difficulty).Return(mockMatch, nil)
+    mockMatchService.On("CreateMatch", player1ID, player2ID, difficulty, mock.Anything).Return(mockMatch, nil)
 
 	// Execute
-	result, err := service.CreateMatch(player1ID, player2ID, difficulty)
+    result, err := service.CreateMatch(player1ID, player2ID, difficulty, "casual_pvp")
 
 	// Assert
 	assert.NoError(t, err)
@@ -106,10 +106,10 @@ func TestMatchmakingService_CreateMatch_MatchServiceError(t *testing.T) {
 
 	// Mock match creation failure
 	expectedError := errors.New("failed to create match")
-	mockMatchService.On("CreateMatch", player1ID, player2ID, difficulty).Return((*model.Match)(nil), expectedError)
+    mockMatchService.On("CreateMatch", player1ID, player2ID, difficulty, mock.Anything).Return((*model.Match)(nil), expectedError)
 
 	// Execute
-	result, err := service.CreateMatch(player1ID, player2ID, difficulty)
+    result, err := service.CreateMatch(player1ID, player2ID, difficulty, "casual_pvp")
 
 	// Assert
 	assert.Error(t, err)

--- a/backend/internal/service/redis_manager.go
+++ b/backend/internal/service/redis_manager.go
@@ -40,6 +40,7 @@ const (
 	FieldFinishedAt = "finished_at"
 	FieldLeetCodeID = "leetcode_id"
 	FieldDifficulty = "difficulty"
+    FieldMode       = "mode"
 )
 
 // NewRedisManager creates a new RedisManager instance
@@ -51,7 +52,7 @@ func NewRedisManager(rdb *redis.Client, logger logger.Logger) *RedisManager {
 }
 
 // CreateMatch creates Redis data structure for a new match
-func (rm *RedisManager) CreateMatch(matchID uuid.UUID, player1ID, player2ID uuid.UUID, leetcodeID uuid.UUID, difficulty string) error {
+func (rm *RedisManager) CreateMatch(matchID uuid.UUID, player1ID, player2ID uuid.UUID, leetcodeID uuid.UUID, difficulty string, mode string) error {
 	ctx := context.Background()
 	now := time.Now()
 
@@ -62,12 +63,13 @@ func (rm *RedisManager) CreateMatch(matchID uuid.UUID, player1ID, player2ID uuid
 
 	// Set match metadata
 	matchDataKey := fmt.Sprintf(MatchDataKey, matchID.String())
-	pipe.HSet(ctx, matchDataKey, map[string]interface{}{
+    pipe.HSet(ctx, matchDataKey, map[string]interface{}{
 		FieldStatus:     string(model.MatchStatusPlaying),
 		FieldCreatedAt:  now.Unix(),
 		FieldStartedAt:  now.Unix(),
 		FieldLeetCodeID: leetcodeID,
-		FieldDifficulty: difficulty,
+        FieldDifficulty: difficulty,
+        FieldMode:       mode,
 	})
 	pipe.Expire(ctx, matchDataKey, codeExpirationHours*time.Hour)
 

--- a/backend/internal/service/websocket_service_test.go
+++ b/backend/internal/service/websocket_service_test.go
@@ -17,8 +17,8 @@ type MockMatchmakingService struct {
 	mock.Mock
 }
 
-func (m *MockMatchmakingService) CreateMatch(player1ID, player2ID uuid.UUID, difficulty string) (interface{}, error) {
-	args := m.Called(player1ID, player2ID, difficulty)
+func (m *MockMatchmakingService) CreateMatch(player1ID, player2ID uuid.UUID, difficulty string, mode string) (interface{}, error) {
+    args := m.Called(player1ID, player2ID, difficulty, mode)
 	return args.Get(0), args.Error(1)
 }
 

--- a/frontend/src/components/game/MatchingScreen.tsx
+++ b/frontend/src/components/game/MatchingScreen.tsx
@@ -180,7 +180,7 @@ export const MatchingScreen: React.FC<MatchingScreenProps> = memo(
                 : ''
             }`}
             disabled={matchingState !== MATCHING_STATE.IDLE}
-            onClick={() => startMatching(difficulty)}
+            onClick={() => startMatching(difficulty, mode)}
           >
             GO
           </button>

--- a/frontend/src/hooks/useMatchmaking.ts
+++ b/frontend/src/hooks/useMatchmaking.ts
@@ -71,7 +71,7 @@ export function useMatchmaking(options: UseMatchmakingOptions = {}) {
     };
   }, []);
 
-  const startMatching = async (difficulty: Difficulty) => {
+  const startMatching = async (difficulty: Difficulty, mode: 'casual_pvp' | 'ranked_pvp' | 'single' = 'casual_pvp') => {
     // Prevent duplicate start: ignore if in progress or existing socket
     if (matchingState !== MATCHING_STATE.IDLE || wsClientRef.current) {
       return;
@@ -89,7 +89,7 @@ export function useMatchmaking(options: UseMatchmakingOptions = {}) {
       const wsClient = new MatchmakingWebSocketClient({
         onConnect: () => {
           setMatchingState(MATCHING_STATE.SEARCHING);
-          wsClient.startMatching(difficulty);
+          wsClient.startMatching(difficulty, mode);
         },
 
         onStatusUpdate: (message: MatchingStatusMessage) => {

--- a/frontend/src/lib/matchmaking-websocket.ts
+++ b/frontend/src/lib/matchmaking-websocket.ts
@@ -5,6 +5,7 @@ import { createErrorHandler } from '@/lib/error-tracking';
 export interface MatchingRequest {
   type: 'start_matching';
   difficulty: 'Easy' | 'Medium' | 'Hard';
+  mode: 'casual_pvp' | 'ranked_pvp' | 'single';
 }
 
 export interface CancelRequest {
@@ -192,7 +193,7 @@ export class MatchmakingWebSocketClient {
     }, delay);
   }
 
-  startMatching(difficulty: 'Easy' | 'Medium' | 'Hard') {
+  startMatching(difficulty: 'Easy' | 'Medium' | 'Hard', mode: 'casual_pvp' | 'ranked_pvp' | 'single' = 'casual_pvp') {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       console.error('WebSocket is not connected');
       return;
@@ -201,6 +202,7 @@ export class MatchmakingWebSocketClient {
     const message: MatchingRequest = {
       type: 'start_matching',
       difficulty,
+      mode,
     };
 
     console.log('🚀 Sending start_matching message:', message);


### PR DESCRIPTION
…\n- hub: matchingClients map[mode]map[difficulty][]client\n- ws: MatchingRequest includes mode; state/status/attempt use mode\n- services: CreateMatch accepts mode; set model.Match.Mode\n- redis: persist mode in match metadata\n- frontend: send mode in start_matching\n- tests: update mocks and expectations; run race