### PR TITLE
feat(frontend): globalize fullscreen context and unify consumers

### DIFF
--- a/frontend/src/components/game/states/EditorPane.tsx
+++ b/frontend/src/components/game/states/EditorPane.tsx
@@ -1,6 +1,7 @@
 import React, { FC, memo } from 'react';
-import { Expand, Minimize2 } from 'lucide-react';
+import { Expand, Minimize } from 'lucide-react';
 import CodeEditor from '../CodeEditor';
+import { useFullscreen } from '@/contexts/FullscreenContext';
 
 interface EditorPaneProps {
   title: string;
@@ -11,7 +12,6 @@ interface EditorPaneProps {
   isMinimized: boolean;
   isResizing: boolean;
   showFullscreenButton?: boolean;
-  isFullscreen?: boolean;
   onChange?: (code: string) => void;
   onFullscreenToggle?: () => void;
 }
@@ -26,10 +26,10 @@ export const EditorPane: FC<EditorPaneProps> = memo(
     isMinimized,
     isResizing,
     showFullscreenButton = false,
-    isFullscreen = false,
     onChange,
     onFullscreenToggle,
   }) => {
+    const { isFullscreen } = useFullscreen();
     const headerClass = `bg-[hsl(var(--muted))] px-4 py-2 flex items-center ${
       isMinimized ? 'justify-center' : 'justify-between'
     }`;
@@ -56,7 +56,7 @@ export const EditorPane: FC<EditorPaneProps> = memo(
                 title={isFullscreen ? 'Exit Fullscreen' : 'Fullscreen'}
               >
                 {isFullscreen ? (
-                  <Minimize2 className="w-4 h-4" />
+                  <Minimize className="w-4 h-4" />
                 ) : (
                   <Expand className="w-4 h-4" />
                 )}

--- a/frontend/src/components/game/states/EditorSplit.tsx
+++ b/frontend/src/components/game/states/EditorSplit.tsx
@@ -13,7 +13,6 @@ interface EditorSplitProps {
   isResizing: boolean;
   sizesNormal: number[];
   showFullscreenButton?: boolean;
-  isFullscreen?: boolean;
   gutterSize?: number;
   onCodeChange: (code: string) => void;
   onMaximizeToggle: (editor: 'my' | 'opponent') => void;
@@ -33,7 +32,6 @@ export const EditorSplit: FC<EditorSplitProps> = memo(
     isResizing,
     sizesNormal,
     showFullscreenButton = false,
-    isFullscreen = false,
     gutterSize = 6,
     onCodeChange,
     onFullscreenToggle,
@@ -62,7 +60,6 @@ export const EditorSplit: FC<EditorSplitProps> = memo(
           isMinimized={maximizedEditor === 'opponent'}
           isResizing={isResizing}
           showFullscreenButton={showFullscreenButton}
-          isFullscreen={isFullscreen}
           onChange={onCodeChange}
           onFullscreenToggle={onFullscreenToggle}
         />

--- a/frontend/src/components/game/states/FullscreenOverlay.tsx
+++ b/frontend/src/components/game/states/FullscreenOverlay.tsx
@@ -36,6 +36,7 @@ export const FullscreenOverlay: FC<FullscreenOverlayProps> = memo(
     onCodeChange,
     onMaximizeToggle,
     onToggleDescription,
+    onClose,
   }) => {
     const [isResizing, setIsResizing] = useState(false);
     const [fsSplitSizes, setFsSplitSizes] = useState<number[]>([50, 50]);
@@ -82,9 +83,11 @@ export const FullscreenOverlay: FC<FullscreenOverlayProps> = memo(
               maximizedEditor={maximizedEditor}
               isResizing={isResizing}
               sizesNormal={fsSplitSizes}
+              showFullscreenButton={true}
               gutterSize={10}
               onCodeChange={onCodeChange}
               onMaximizeToggle={onMaximizeToggle}
+              onFullscreenToggle={onClose}
               onDragStart={handleDragStart}
               onDragEnd={handleDragEnd}
             />

--- a/frontend/src/components/game/states/PlayingGame.tsx
+++ b/frontend/src/components/game/states/PlayingGame.tsx
@@ -9,6 +9,7 @@ import { Alert } from '@/components/ui/alert';
 import { ProblemDetailsPane } from './ProblemDetailsPane';
 import { EditorPane } from './EditorPane';
 import { FullscreenOverlay } from './FullscreenOverlay';
+import { useFullscreen } from '@/contexts/FullscreenContext';
 
 interface PlayingGameProps {
   game: Game;
@@ -40,6 +41,7 @@ export const PlayingGame: FC<PlayingGameProps> = ({
   onSubmitCode,
 }) => {
   const { theme } = useTheme();
+  const { isFullscreen, setIsFullscreen } = useFullscreen();
   const [maximizedEditor, setMaximizedEditor] = useState<
     'my' | 'opponent' | null
   >(null);
@@ -60,7 +62,7 @@ export const PlayingGame: FC<PlayingGameProps> = ({
     setIsFullscreenMy((prev) => !prev);
   }, []);
 
-  // ESC to exit fullscreen and body scroll lock
+  // ESC to exit fullscreen
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -69,39 +71,39 @@ export const PlayingGame: FC<PlayingGameProps> = ({
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, []);
+  }, [setIsFullscreen]);
 
+  // Sync local fullscreen toggle with global context
   useEffect(() => {
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = isFullscreenMy ? 'hidden' : prev || '';
-    return () => {
-      document.body.style.overflow = prev || '';
-    };
-  }, [isFullscreenMy]);
+    setIsFullscreen(isFullscreenMy);
+    return () => setIsFullscreen(false);
+  }, [isFullscreenMy, setIsFullscreen]);
 
   return (
     <div className="flex flex-col h-screen">
       {/* Header */}
-      <div className="p-4 grid grid-cols-12 gap-4 mb-4">
-        <div className="col-span-12 md:col-span-8">
-          <h1 className="text-2xl font-bold">{game.leetcode.title}</h1>
-          <div className="flex items-center gap-4 mt-2">
-            <LanguageSelector
-              selectedLanguage={selectedLanguage}
-              onChange={onLanguageChange}
-            />
+      {!isFullscreen && (
+        <div className="p-4 grid grid-cols-12 gap-4 mb-4">
+          <div className="col-span-12 md:col-span-8">
+            <h1 className="text-2xl font-bold">{game.leetcode.title}</h1>
+            <div className="flex items-center gap-4 mt-2">
+              <LanguageSelector
+                selectedLanguage={selectedLanguage}
+                onChange={onLanguageChange}
+              />
+            </div>
+          </div>
+          <div className="col-span-12 md:col-span-4 flex justify-end items-start">
+            <Button
+              onClick={onSubmitCode}
+              disabled={submitting}
+              className="w-full md:w-auto"
+            >
+              {submitting ? <Spinner size="sm" /> : 'Submit Solution'}
+            </Button>
           </div>
         </div>
-        <div className="col-span-12 md:col-span-4 flex justify-end items-start">
-          <Button
-            onClick={onSubmitCode}
-            disabled={submitting}
-            className="w-full md:w-auto"
-          >
-            {submitting ? <Spinner size="sm" /> : 'Submit Solution'}
-          </Button>
-        </div>
-      </div>
+      )}
 
       {/* Submit Result Alert */}
       {submitResult && (
@@ -113,7 +115,7 @@ export const PlayingGame: FC<PlayingGameProps> = ({
         </Alert>
       )}
 
-      {!isFullscreenMy ? (
+      {!isFullscreen ? (
         <div
           className="flex-1 px-4 py-4 flex min-h-0 game-editor-container"
           style={{ width: '100%' }}
@@ -180,7 +182,6 @@ export const PlayingGame: FC<PlayingGameProps> = ({
                 isMinimized={maximizedEditor === 'opponent'}
                 isResizing={isResizing}
                 showFullscreenButton={true}
-                isFullscreen={isFullscreenMy}
                 onChange={onCodeChange}
                 onFullscreenToggle={handleToggleFullscreen}
               />

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,8 +1,11 @@
+'use client';
+
 import React from 'react';
 import Head from 'next/head';
 import { Footer } from './Footer';
 import Header from './Header';
 import { Contributor } from './Contributors';
+import { useFullscreen } from '@/contexts/FullscreenContext';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -17,6 +20,8 @@ const Layout: React.FC<LayoutProps> = ({
   description,
   contributors,
 }) => {
+  const { isFullscreen } = useFullscreen();
+
   return (
     <>
       <Head>
@@ -28,9 +33,9 @@ const Layout: React.FC<LayoutProps> = ({
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <div className="min-h-screen flex flex-col">
-        <Header />
+        {!isFullscreen && <Header />}
         <main className="flex-grow">{children}</main>
-        <Footer contributors={contributors ?? []} />
+        {!isFullscreen && <Footer contributors={contributors ?? []} />}
       </div>
     </>
   );

--- a/frontend/src/contexts/FullscreenContext.tsx
+++ b/frontend/src/contexts/FullscreenContext.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  ReactNode,
+  FC,
+} from 'react';
+
+interface FullscreenContextType {
+  isFullscreen: boolean;
+  setIsFullscreen: (value: boolean) => void;
+}
+
+const FullscreenContext = createContext<FullscreenContextType | undefined>(
+  undefined
+);
+
+export const FullscreenProvider: FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  return (
+    <FullscreenContext.Provider value={{ isFullscreen, setIsFullscreen }}>
+      {children}
+    </FullscreenContext.Provider>
+  );
+};
+
+export const useFullscreen = () => {
+  const context = useContext(FullscreenContext);
+  if (!context) {
+    throw new Error('useFullscreen must be used within FullscreenProvider');
+  }
+  return context;
+};

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -8,6 +8,7 @@ import { Analytics } from '@vercel/analytics/react';
 import AdminLayout from '../components/admin/AdminLayout';
 import '../styles/globals.css';
 import { useAuthStore } from '../stores/authStore';
+import { FullscreenProvider } from '../contexts/FullscreenContext';
 
 function MyApp({ Component, pageProps }: AppProps) {
   const { initializeAuth } = useAuthStore();
@@ -34,18 +35,20 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <NextThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <QueryClientProvider client={queryClient}>
-        {isAdminRoute ? (
-          <>
-            <Head>
-              <title>{adminTitle}</title>
-            </Head>
-            <AdminLayout>
-              <Component {...pageProps} />
-            </AdminLayout>
-          </>
-        ) : (
-          <Component {...pageProps} />
-        )}
+        <FullscreenProvider>
+          {isAdminRoute ? (
+            <>
+              <Head>
+                <title>{adminTitle}</title>
+              </Head>
+              <AdminLayout>
+                <Component {...pageProps} />
+              </AdminLayout>
+            </>
+          ) : (
+            <Component {...pageProps} />
+          )}
+        </FullscreenProvider>
       </QueryClientProvider>
       <Analytics />
     </NextThemeProvider>


### PR DESCRIPTION
- add 'use client' to FullscreenContext and Layout
- wrap app with FullscreenProvider in _app
- sync PlayingGame local fullscreen state with context and branch by isFullscreen
- refactor EditorPane to use useFullscreen; remove console log
- update EditorSplit and FullscreenOverlay to pass fullscreen toggle button and handler

Behavior: in fullscreen, hide header/footer and base editor; show overlay only