### PR TITLE
fix(frontend): sync selected language state and selector display\n\n-…

### DIFF
--- a/frontend/src/components/game/GameRoom.tsx
+++ b/frontend/src/components/game/GameRoom.tsx
@@ -32,6 +32,7 @@ const GameRoom: FC<GameRoomProps> = ({ gameId: matchId }) => {
     submitting,
     setSubmitting,
     selectedLanguage,
+    setSelectedLanguage,
     showMyCode,
     setShowMyCode,
     showOpponentCode,
@@ -51,6 +52,7 @@ const GameRoom: FC<GameRoomProps> = ({ gameId: matchId }) => {
       setOpponentCode,
       setSubmitResult,
       setSubmitting,
+      setSelectedLanguage,
       refetchGame,
     });
 

--- a/frontend/src/components/game/LanguageSelector.tsx
+++ b/frontend/src/components/game/LanguageSelector.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 
-// 지원하는 언어 목록
+// 지원하는 언어 목록 (게임에서 사용하는 3종으로 제한)
 const LANGUAGES = [
   { id: 'javascript', name: 'JavaScript' },
   { id: 'python', name: 'Python' },
-  { id: 'java', name: 'Java' },
-  { id: 'rust', name: 'Rust' },
-  { id: 'cpp', name: 'C++' },
   { id: 'go', name: 'Go' },
-];
+] as const;
+
+type SupportedLanguage = (typeof LANGUAGES)[number]['id'];
 
 interface LanguageSelectorProps {
-  selectedLanguage: string;
-  onChange: (language: 'python' | 'javascript' | 'go') => void;
+  selectedLanguage: SupportedLanguage;
+  onChange: (language: SupportedLanguage) => void;
   disabled?: boolean;
 }
 
@@ -29,7 +28,7 @@ const LanguageSelector: React.FC<LanguageSelectorProps> = ({
       <select
         id="language-select"
         value={selectedLanguage}
-        onChange={(e) => onChange(e.target.value as 'python' | 'javascript')}
+        onChange={(e) => onChange(e.target.value as SupportedLanguage)}
         disabled={disabled}
         className="py-1 px-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-50"
       >

--- a/frontend/src/components/game/hooks/useGameRoomWebSocket.ts
+++ b/frontend/src/components/game/hooks/useGameRoomWebSocket.ts
@@ -19,6 +19,7 @@ interface UseGameRoomWebSocketProps {
   setOpponentCode: (code: string) => void;
   setSubmitResult: (result: SubmitResult | null) => void;
   setSubmitting: (submitting: boolean) => void;
+  setSelectedLanguage: (language: SupportedLanguage) => void;
   refetchGame: () => void;
 }
 
@@ -32,6 +33,7 @@ export const useGameRoomWebSocket = ({
   setOpponentCode,
   setSubmitResult,
   setSubmitting,
+  setSelectedLanguage,
   refetchGame,
 }: UseGameRoomWebSocketProps) => {
   const router = useRouter();
@@ -128,6 +130,7 @@ export const useGameRoomWebSocket = ({
     (newLanguage: SupportedLanguage) => {
       setSubmitting(false);
       setSubmitResult(null);
+      setSelectedLanguage(newLanguage);
 
       if (game?.leetcode) {
         const template = getCodeTemplate(game.leetcode, newLanguage);
@@ -138,7 +141,13 @@ export const useGameRoomWebSocket = ({
         }
       }
     },
-    [game?.leetcode, setMyCode, setSubmitting, setSubmitResult]
+    [
+      game?.leetcode,
+      setMyCode,
+      setSubmitting,
+      setSubmitResult,
+      setSelectedLanguage,
+    ]
   );
 
   // Code submission handler


### PR DESCRIPTION
… Limit LanguageSelector options to javascript/python/go and align types\n- Update onChange to include 'go'\n- Wire setSelectedLanguage through GameRoom -> useGameRoomWebSocket\n- Update handleLanguageChange to setSelectedLanguage(newLanguage) so UI reflects selection immediately\n\nResult: selecting Go updates selector value and template consistently

Related to #45 