### PR TITLE
fix(frontend): persist DashboardLayout sidebar collapse state across …

### DIFF
--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -28,10 +28,19 @@ const navigationItems = [
 
 export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const router = useRouter();
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('dashboard-sidebar-collapsed') === 'true';
+    }
+    return false;
+  });
 
   const toggleSidebar = () => {
-    setIsCollapsed(!isCollapsed);
+    const newState = !isCollapsed;
+    setIsCollapsed(newState);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('dashboard-sidebar-collapsed', newState.toString());
+    }
   };
 
   return (


### PR DESCRIPTION
…navigation\n\n- Store collapse state in localStorage to prevent reset on page navigation\n- Initialize useState from localStorage value with SSR-safe check\n- Update localStorage on toggle to maintain state across sessions\n\nFixes issue where sidebar would always expand after navigation