### PR TITLE
feat: add single player practice mode

### DIFF
--- a/backend/internal/interfaces/match_interfaces.go
+++ b/backend/internal/interfaces/match_interfaces.go
@@ -5,8 +5,11 @@ import (
 	"github.com/google/uuid"
 )
 
-// GameCreator는 게임 생성 기능만 담당하는 인터페이스
-type ASasdasd interface {
-	CreateGameForMatch(player1ID, player2ID uuid.UUID, difficulty string) (*model.Match, error)
+// MatchService defines the interface for match-related operations
+type MatchService interface {
+	CreateMatch(player1ID, player2ID uuid.UUID, difficulty string, mode string) (*model.Match, error)
+	CreateSinglePlayerMatch(playerID uuid.UUID, difficulty string) (*model.Match, error)
+	GetMatch(matchID uuid.UUID) (*model.Match, error)
 	GetRandomLeetCodeByDifficulty(difficulty string) (*model.LeetCode, error)
+	SubmitSolution(matchID, userID uuid.UUID, req *model.SubmitSolutionRequest) (*model.SubmitSolutionResponse, error)
 }

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -79,6 +79,7 @@ func Setup(
 			{
 				match.GET("/:id", matchController.GetMatch)
 				match.POST("/:id/submit", matchController.SubmitSolution)
+				match.POST("/single", matchController.CreateSinglePlayerMatch)
 			}
 
 			// users

--- a/backend/internal/service/matchmaking_service.go
+++ b/backend/internal/service/matchmaking_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"github.com/Dongmoon29/code_racer/internal/events"
+	"github.com/Dongmoon29/code_racer/internal/interfaces"
 	"github.com/Dongmoon29/code_racer/internal/logger"
 	"github.com/go-redis/redis/v8"
 	"github.com/google/uuid"
@@ -10,10 +11,11 @@ import (
 // MatchmakingService handles player matching and game creation
 type MatchmakingService interface {
 	CreateMatch(player1ID, player2ID uuid.UUID, difficulty string, mode string) (interface{}, error)
+	CreateSinglePlayerMatch(playerID uuid.UUID, difficulty string) (interface{}, error)
 }
 
 type matchmakingService struct {
-	matchService MatchService
+	matchService interfaces.MatchService
 	rdb          *redis.Client
 	logger       logger.Logger
 	eventBus     events.EventBus
@@ -21,7 +23,7 @@ type matchmakingService struct {
 
 // NewMatchmakingService creates a new matchmaking service
 func NewMatchmakingService(
-	matchService MatchService,
+	matchService interfaces.MatchService,
 	rdb *redis.Client,
 	logger logger.Logger,
 	opts ...interface{},
@@ -60,6 +62,32 @@ func (s *matchmakingService) CreateMatch(player1ID, player2ID uuid.UUID, difficu
 		Str("player1ID", player1ID.String()).
 		Str("player2ID", player2ID.String()).
 		Msg("Match created successfully")
+
+	// Publish event if bus is configured
+	if s.eventBus != nil {
+		s.eventBus.Publish(events.TopicMatchCreated, &events.MatchCreatedEvent{Match: match})
+	}
+
+	return match, nil
+}
+
+// CreateSinglePlayerMatch handles single player match creation
+func (s *matchmakingService) CreateSinglePlayerMatch(playerID uuid.UUID, difficulty string) (interface{}, error) {
+	s.logger.Info().
+		Str("playerID", playerID.String()).
+		Str("difficulty", difficulty).
+		Msg("Starting single player match creation")
+
+	match, err := s.matchService.CreateSinglePlayerMatch(playerID, difficulty)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("Failed to create single player match")
+		return nil, err
+	}
+
+	s.logger.Info().
+		Str("matchID", match.ID.String()).
+		Str("playerID", playerID.String()).
+		Msg("Single player match created successfully")
 
 	// Publish event if bus is configured
 	if s.eventBus != nil {

--- a/backend/internal/service/matchmaking_service_test.go
+++ b/backend/internal/service/matchmaking_service_test.go
@@ -39,7 +39,12 @@ func (m *MockMatchService) GetRandomLeetCodeByDifficulty(difficulty string) (*mo
 }
 
 func (m *MockMatchService) CreateMatch(player1ID, player2ID uuid.UUID, difficulty string, mode string) (*model.Match, error) {
-    args := m.Called(player1ID, player2ID, difficulty, mode)
+	args := m.Called(player1ID, player2ID, difficulty, mode)
+	return args.Get(0).(*model.Match), args.Error(1)
+}
+
+func (m *MockMatchService) CreateSinglePlayerMatch(playerID uuid.UUID, difficulty string) (*model.Match, error) {
+	args := m.Called(playerID, difficulty)
 	return args.Get(0).(*model.Match), args.Error(1)
 }
 
@@ -81,10 +86,10 @@ func TestMatchmakingService_CreateMatch_Success(t *testing.T) {
 
 	// Mock match creation success
 	mockMatch := &model.Match{ID: uuid.New()}
-    mockMatchService.On("CreateMatch", player1ID, player2ID, difficulty, mock.Anything).Return(mockMatch, nil)
+	mockMatchService.On("CreateMatch", player1ID, player2ID, difficulty, mock.Anything).Return(mockMatch, nil)
 
 	// Execute
-    result, err := service.CreateMatch(player1ID, player2ID, difficulty, "casual_pvp")
+	result, err := service.CreateMatch(player1ID, player2ID, difficulty, "casual_pvp")
 
 	// Assert
 	assert.NoError(t, err)
@@ -106,10 +111,10 @@ func TestMatchmakingService_CreateMatch_MatchServiceError(t *testing.T) {
 
 	// Mock match creation failure
 	expectedError := errors.New("failed to create match")
-    mockMatchService.On("CreateMatch", player1ID, player2ID, difficulty, mock.Anything).Return((*model.Match)(nil), expectedError)
+	mockMatchService.On("CreateMatch", player1ID, player2ID, difficulty, mock.Anything).Return((*model.Match)(nil), expectedError)
 
 	// Execute
-    result, err := service.CreateMatch(player1ID, player2ID, difficulty, "casual_pvp")
+	result, err := service.CreateMatch(player1ID, player2ID, difficulty, "casual_pvp")
 
 	// Assert
 	assert.Error(t, err)

--- a/backend/internal/service/websocket_service_test.go
+++ b/backend/internal/service/websocket_service_test.go
@@ -18,7 +18,12 @@ type MockMatchmakingService struct {
 }
 
 func (m *MockMatchmakingService) CreateMatch(player1ID, player2ID uuid.UUID, difficulty string, mode string) (interface{}, error) {
-    args := m.Called(player1ID, player2ID, difficulty, mode)
+	args := m.Called(player1ID, player2ID, difficulty, mode)
+	return args.Get(0), args.Error(1)
+}
+
+func (m *MockMatchmakingService) CreateSinglePlayerMatch(playerID uuid.UUID, difficulty string) (interface{}, error) {
+	args := m.Called(playerID, difficulty)
 	return args.Get(0), args.Error(1)
 }
 

--- a/frontend/src/api/game.ts
+++ b/frontend/src/api/game.ts
@@ -5,4 +5,13 @@ export const closeGame = async (gameId: string): Promise<ApiResponse> => {
   const response = await axios.post(`/games/${gameId}/close`);
   return response.data;
 };
+
+export const createSinglePlayerMatch = async (
+  difficulty: string
+): Promise<ApiResponse> => {
+  const response = await axios.post('/api/matches/single', {
+    difficulty,
+  });
+  return response.data;
+};
 //

--- a/frontend/src/components/game/GameRoom.tsx
+++ b/frontend/src/components/game/GameRoom.tsx
@@ -62,6 +62,11 @@ const GameRoom: FC<GameRoomProps> = ({ gameId: matchId }) => {
     [game?.status]
   );
 
+  const isSinglePlayerMode = useMemo(
+    () => game?.mode === 'single',
+    [game?.mode]
+  );
+
   const sessionStorageKeys = useMemo(
     () => ({
       code: `match_${matchId}_code`,
@@ -151,10 +156,10 @@ const GameRoom: FC<GameRoomProps> = ({ gameId: matchId }) => {
       game={game}
       currentUser={currentUser}
       myCode={myCode}
-      opponentCode={opponentCode}
+      opponentCode={isSinglePlayerMode ? '' : opponentCode}
       selectedLanguage={selectedLanguage}
       showMyCode={showMyCode}
-      showOpponentCode={showOpponentCode}
+      showOpponentCode={isSinglePlayerMode ? false : showOpponentCode}
       submitResult={submitResult}
       submitting={submitting}
       onCodeChange={handleCodeChange}

--- a/frontend/src/components/game/states/EditorSplit.tsx
+++ b/frontend/src/components/game/states/EditorSplit.tsx
@@ -19,6 +19,7 @@ interface EditorSplitProps {
   onFullscreenToggle?: () => void;
   onDragStart: () => void;
   onDragEnd: (sizes: number[]) => void;
+  isSinglePlayerMode?: boolean;
 }
 
 export const EditorSplit: FC<EditorSplitProps> = memo(
@@ -37,6 +38,7 @@ export const EditorSplit: FC<EditorSplitProps> = memo(
     onFullscreenToggle,
     onDragStart,
     onDragEnd,
+    isSinglePlayerMode = false,
   }) => {
     const splitConfig = useSplitConfig(
       maximizedEditor,
@@ -45,34 +47,52 @@ export const EditorSplit: FC<EditorSplitProps> = memo(
     );
 
     return (
-      <Split
-        className="flex w-full h-full"
-        direction="horizontal"
-        {...splitConfig}
-        onDragStart={onDragStart}
-        onDragEnd={(sizes) => onDragEnd(sizes as number[])}
-      >
-        <EditorPane
-          title="Me"
-          code={myCode}
-          language={selectedLanguage}
-          theme={theme}
-          isMinimized={maximizedEditor === 'opponent'}
-          isResizing={isResizing}
-          showFullscreenButton={showFullscreenButton}
-          onChange={onCodeChange}
-          onFullscreenToggle={onFullscreenToggle}
-        />
-        <EditorPane
-          title={opponentName ?? ''}
-          code={opponentCode}
-          language={selectedLanguage}
-          theme={theme}
-          readOnly={true}
-          isMinimized={maximizedEditor === 'my'}
-          isResizing={isResizing}
-        />
-      </Split>
+      <>
+        {isSinglePlayerMode ? (
+          // Single player mode - only show one editor
+          <EditorPane
+            title="Practice Mode"
+            code={myCode}
+            language={selectedLanguage}
+            theme={theme}
+            isMinimized={false}
+            isResizing={false}
+            showFullscreenButton={showFullscreenButton}
+            onChange={onCodeChange}
+            onFullscreenToggle={onFullscreenToggle}
+          />
+        ) : (
+          // Multiplayer mode - show split editors
+          <Split
+            className="flex w-full h-full"
+            direction="horizontal"
+            {...splitConfig}
+            onDragStart={onDragStart}
+            onDragEnd={(sizes) => onDragEnd(sizes as number[])}
+          >
+            <EditorPane
+              title="Me"
+              code={myCode}
+              language={selectedLanguage}
+              theme={theme}
+              isMinimized={maximizedEditor === 'opponent'}
+              isResizing={isResizing}
+              showFullscreenButton={showFullscreenButton}
+              onChange={onCodeChange}
+              onFullscreenToggle={onFullscreenToggle}
+            />
+            <EditorPane
+              title={opponentName ?? ''}
+              code={opponentCode}
+              language={selectedLanguage}
+              theme={theme}
+              readOnly={true}
+              isMinimized={maximizedEditor === 'my'}
+              isResizing={isResizing}
+            />
+          </Split>
+        )}
+      </>
     );
   }
 );

--- a/frontend/src/components/game/states/FullscreenOverlay.tsx
+++ b/frontend/src/components/game/states/FullscreenOverlay.tsx
@@ -18,6 +18,7 @@ interface FullscreenOverlayProps {
   onMaximizeToggle: (editor: 'my' | 'opponent') => void;
   onToggleDescription: () => void;
   onClose: () => void;
+  isSinglePlayerMode?: boolean;
 }
 
 export const FullscreenOverlay: FC<FullscreenOverlayProps> = memo(
@@ -37,6 +38,7 @@ export const FullscreenOverlay: FC<FullscreenOverlayProps> = memo(
     onMaximizeToggle,
     onToggleDescription,
     onClose,
+    isSinglePlayerMode = false,
   }) => {
     const [isResizing, setIsResizing] = useState(false);
     const [fsSplitSizes, setFsSplitSizes] = useState<number[]>([50, 50]);
@@ -74,23 +76,46 @@ export const FullscreenOverlay: FC<FullscreenOverlayProps> = memo(
           </div>
 
           <div className="flex-1 p-2 min-h-0 overflow-hidden">
-            <EditorSplit
-              myCode={myCode}
-              opponentCode={opponentCode}
-              opponentName={opponentName}
-              selectedLanguage={selectedLanguage}
-              theme={theme}
-              maximizedEditor={maximizedEditor}
-              isResizing={isResizing}
-              sizesNormal={fsSplitSizes}
-              showFullscreenButton={true}
-              gutterSize={10}
-              onCodeChange={onCodeChange}
-              onMaximizeToggle={onMaximizeToggle}
-              onFullscreenToggle={onClose}
-              onDragStart={handleDragStart}
-              onDragEnd={handleDragEnd}
-            />
+            {isSinglePlayerMode ? (
+              // Single player mode - only show one editor
+              <EditorSplit
+                myCode={myCode}
+                opponentCode=""
+                opponentName=""
+                selectedLanguage={selectedLanguage}
+                theme={theme}
+                maximizedEditor={null}
+                isResizing={false}
+                sizesNormal={[100]}
+                showFullscreenButton={true}
+                gutterSize={10}
+                onCodeChange={onCodeChange}
+                onMaximizeToggle={() => {}}
+                onFullscreenToggle={onClose}
+                onDragStart={() => {}}
+                onDragEnd={() => {}}
+                isSinglePlayerMode={true}
+              />
+            ) : (
+              // Multiplayer mode - show split editors
+              <EditorSplit
+                myCode={myCode}
+                opponentCode={opponentCode}
+                opponentName={opponentName}
+                selectedLanguage={selectedLanguage}
+                theme={theme}
+                maximizedEditor={maximizedEditor}
+                isResizing={isResizing}
+                sizesNormal={fsSplitSizes}
+                showFullscreenButton={true}
+                gutterSize={10}
+                onCodeChange={onCodeChange}
+                onMaximizeToggle={onMaximizeToggle}
+                onFullscreenToggle={onClose}
+                onDragStart={handleDragStart}
+                onDragEnd={handleDragEnd}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/components/game/states/PlayingGame.tsx
+++ b/frontend/src/components/game/states/PlayingGame.tsx
@@ -50,6 +50,8 @@ export const PlayingGame: FC<PlayingGameProps> = memo(({
   const [sizesNormal, setSizesNormal] = useState<number[]>([50, 50]);
   const [isResizing, setIsResizing] = useState(false);
 
+  const isSinglePlayerMode = game.mode === 'single';
+
   const handleMaximizeToggle = useCallback((editor: 'my' | 'opponent') => {
     setMaximizedEditor((current) => (current === editor ? null : editor));
   }, []);
@@ -138,82 +140,99 @@ export const PlayingGame: FC<PlayingGameProps> = memo(({
 
           {/* Editor Panes */}
           <div className="flex-1 ml-4">
-            <Split
-              className="flex w-full h-full"
-              sizes={
-                maximizedEditor === 'my'
-                  ? [100, 0]
-                  : maximizedEditor === 'opponent'
-                  ? [0, 100]
-                  : sizesNormal
-              }
-              minSize={0}
-              gutterSize={6}
-              snapOffset={0}
-              dragInterval={1}
-              cursor="col-resize"
-              onDragStart={() => {
-                setIsResizing(true);
-                document.body.classList.add('resizing');
-              }}
-              onDragEnd={(sizes) => {
-                setIsResizing(false);
-                setSizesNormal(sizes as number[]);
-                document.body.classList.remove('resizing');
-              }}
-              gutter={(index, dir) => {
-                const g = document.createElement('div');
-                g.className = `gutter gutter-${dir}`;
-                g.style.cursor =
-                  dir === 'horizontal' ? 'col-resize' : 'row-resize';
-                if (dir === 'horizontal') {
-                  g.style.width = '6px';
-                }
-                g.style.background = 'transparent';
-                g.style.zIndex = '10';
-                return g;
-              }}
-            >
+            {isSinglePlayerMode ? (
+              // Single player mode - only show one editor
               <EditorPane
-                title="Me"
+                title="Practice Mode"
                 code={myCode}
                 language={selectedLanguage}
                 theme={theme}
-                isMinimized={maximizedEditor === 'opponent'}
-                isResizing={isResizing}
+                isMinimized={false}
+                isResizing={false}
                 showFullscreenButton={true}
                 onChange={onCodeChange}
                 onFullscreenToggle={handleToggleFullscreen}
               />
-              <EditorPane
-                title={opponentName ?? ''}
-                code={opponentCode}
-                language={selectedLanguage}
-                theme={theme}
-                readOnly={true}
-                isMinimized={maximizedEditor === 'my'}
-                isResizing={isResizing}
-              />
-            </Split>
+            ) : (
+              // Multiplayer mode - show split editors
+              <Split
+                className="flex w-full h-full"
+                sizes={
+                  maximizedEditor === 'my'
+                    ? [100, 0]
+                    : maximizedEditor === 'opponent'
+                    ? [0, 100]
+                    : sizesNormal
+                }
+                minSize={0}
+                gutterSize={6}
+                snapOffset={0}
+                dragInterval={1}
+                cursor="col-resize"
+                onDragStart={() => {
+                  setIsResizing(true);
+                  document.body.classList.add('resizing');
+                }}
+                onDragEnd={(sizes) => {
+                  setIsResizing(false);
+                  setSizesNormal(sizes as number[]);
+                  document.body.classList.remove('resizing');
+                }}
+                gutter={(index, dir) => {
+                  const g = document.createElement('div');
+                  g.className = `gutter gutter-${dir}`;
+                  g.style.cursor =
+                    dir === 'horizontal' ? 'col-resize' : 'row-resize';
+                  if (dir === 'horizontal') {
+                    g.style.width = '6px';
+                  }
+                  g.style.background = 'transparent';
+                  g.style.zIndex = '10';
+                  return g;
+                }}
+              >
+                <EditorPane
+                  title="Me"
+                  code={myCode}
+                  language={selectedLanguage}
+                  theme={theme}
+                  isMinimized={maximizedEditor === 'opponent'}
+                  isResizing={isResizing}
+                  showFullscreenButton={true}
+                  onChange={onCodeChange}
+                  onFullscreenToggle={handleToggleFullscreen}
+                />
+                <EditorPane
+                  title={opponentName ?? ''}
+                  code={opponentCode}
+                  language={selectedLanguage}
+                  theme={theme}
+                  readOnly={true}
+                  isMinimized={maximizedEditor === 'my'}
+                  isResizing={isResizing}
+                />
+              </Split>
+            )}
           </div>
         </div>
       ) : (
         <FullscreenOverlay
           myCode={myCode}
-          opponentCode={opponentCode}
-          opponentName={opponentName}
+          opponentCode={isSinglePlayerMode ? '' : opponentCode}
+          opponentName={isSinglePlayerMode ? '' : opponentName}
           selectedLanguage={selectedLanguage}
           theme={theme}
-          maximizedEditor={maximizedEditor}
+          maximizedEditor={isSinglePlayerMode ? null : maximizedEditor}
           isDescriptionExpanded={isDescriptionExpanded}
           problemTitle={game.leetcode.title}
           problemDescription={game.leetcode.description}
           problemExamples={game.leetcode.examples}
           problemConstraints={game.leetcode.constraints}
           onCodeChange={onCodeChange}
-          onMaximizeToggle={handleMaximizeToggle}
+          onMaximizeToggle={isSinglePlayerMode ? () => {} : handleMaximizeToggle}
           onToggleDescription={handleToggleDescription}
           onClose={handleToggleFullscreen}
+          isSinglePlayerMode={isSinglePlayerMode}
         />
       )}
     </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -170,6 +170,7 @@ export const matchApi = {
         : undefined,
       leetcode: payload.leetcode,
       status: payload.status,
+      mode: payload.mode || 'casual_pvp', // Add mode field mapping
       started_at: payload.started_at,
       created_at: payload.created_at,
       player_count: payload.player_b ? 2 : 1,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -198,6 +198,7 @@ export interface Game {
   };
   leetcode: LeetCodeDetail;
   status: 'waiting' | 'playing' | 'finished' | 'closed';
+  mode: 'ranked_pvp' | 'casual_pvp' | 'single';
   started_at?: string;
   created_at: string;
   player_count: number;


### PR DESCRIPTION
Implement single player mode allowing users to practice coding problems alone:
- Add CreateSinglePlayerMatch endpoint (POST /api/matches/single)
- Create Redis data structures for single player matches
- Update frontend to hide opponent editor in single player mode
- Add difficulty validation and match creation flow
- Support for single mode in match service and matchmaking service

Backend changes:
- New match controller method for single player match creation
- Redis manager support for single player match initialization
- Update match interfaces to include single player methods
- Add proper logging and error handling

Frontend changes:
- Conditional rendering of split/single editor based on mode
- Hide opponent code and controls in single player mode
- Update matchmaking hook to support single player requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)